### PR TITLE
Simplify Railway deployment configuration

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import {NextResponse} from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({status: 'ok'})
+}

--- a/railway.toml
+++ b/railway.toml
@@ -3,11 +3,11 @@ builder = "nixpacks"
 buildCommand = "npx prisma generate && next build"
 
 [deploy]
-startCommand = "DATABASE_URL=$DATABASE_URL_PUBLIC npx prisma migrate deploy && npm start"
+startCommand = "npm start"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
-healthcheckPath = "/api/auth/session"
-healthcheckTimeout = 100
+healthcheckPath = "/api/health"
+healthcheckTimeout = 30000
 
 [environment]
 NODE_ENV = "production"


### PR DESCRIPTION
- Remove migrations from startup (run manually if needed)
- Increase healthcheck timeout to 30 seconds
- Add simple /api/health endpoint for healthchecks
- Avoids potential migration hanging issues during deployment